### PR TITLE
Add support for specifying the default value for the 'blank' schema field.

### DIFF
--- a/validictory/__init__.py
+++ b/validictory/__init__.py
@@ -7,7 +7,7 @@ __version__ = '0.7.1'
 
 
 def validate(data, schema, validator_cls=SchemaValidator,
-             format_validators=None, required_by_default=True):
+             format_validators=None, required_by_default=True, blank_by_default=False):
     '''
     Validates a parsed json document against the provided schema. If an
     error is found a :class:`ValidationError` is raised.
@@ -23,7 +23,7 @@ def validate(data, schema, validator_cls=SchemaValidator,
     :param required_by_default: defaults to True, set to False to make
         ``required`` schema attribute False by default.
     '''
-    v = validator_cls(format_validators, required_by_default)
+    v = validator_cls(format_validators, required_by_default, blank_by_default)
     return v.validate(data, schema)
 
 if __name__ == '__main__':

--- a/validictory/tests/test_values.py
+++ b/validictory/tests/test_values.py
@@ -425,18 +425,42 @@ class TestMaxLength(TestCase):
 
 class TestBlank(TestCase):
 
-    def test_blank_default(self):
+    def test_blank_default_false(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "required": True,
+                }
+            }
+        }
         try:
-            validictory.validate("test", {})
+            validictory.validate({"key": "value"}, {}, blank_by_default=False)
         except ValueError, e:
             self.fail("Unexpected failure: %s" % e)
 
-        self.assertRaises(ValueError, validictory.validate, "", {})
+        self.assertRaises(ValueError, validictory.validate, {"key": ""}, schema)
+
+    def test_blank_default_true(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "required": True,
+                }
+            }
+        }
+        try:
+            validictory.validate({"key": ""}, schema, blank_by_default=True)
+        except ValueError, e:
+            self.fail("Unexpected failure: %s" % e)
 
     def test_blank_false(self):
         schema = {"blank":False}
         try:
-            validictory.validate("test", schema)
+            validictory.validate("test", schema, blank_by_default=True)
         except ValueError, e:
             self.fail("Unexpected failure: %s" % e)
 
@@ -444,8 +468,8 @@ class TestBlank(TestCase):
 
     def test_blank_true(self):
         try:
-            validictory.validate("", {"blank":True})
-            validictory.validate("test", {"blank":True})
+            validictory.validate("", {"blank":True}, blank_by_default=False)
+            validictory.validate("test", {"blank":True}, blank_by_default=False)
         except ValueError, e:
             self.fail("Unexpected failure: %s" % e)
 

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -62,14 +62,17 @@ class SchemaValidator(object):
     :param format_validators: optional dictionary of custom format validators
     :param required_by_default: defaults to True, set to False to make
         ``required`` schema attribute False by default.
+    :param blank_by_default: defaults to False, set to True to make ``blank``
+        schema attribute True by default.
     '''
 
-    def __init__(self, format_validators=None, required_by_default=True):
+    def __init__(self, format_validators=None, required_by_default=True, blank_by_default=False):
         if format_validators is None:
             format_validators = DEFAULT_FORMAT_VALIDATORS.copy()
 
         self._format_validators = format_validators
         self.required_by_default = required_by_default
+        self.blank_by_default = blank_by_default
 
     def register_format_validator(self, format_name, format_validator_fun):
         self._format_validators[format_name] = format_validator_fun
@@ -485,7 +488,7 @@ class SchemaValidator(object):
                 newschema['required'] = self.required_by_default
 
             if 'blank' not in schema:
-                newschema['blank'] = False
+                newschema['blank'] = self.blank_by_default
 
             for schemaprop in newschema:
 


### PR DESCRIPTION
The default behavior is unchanged but now it's possible to set the default mode for blank. I need control over this aspect without having to incorporate it into the schema definition.

Blank is not part of the JSON schema spec 03, is it?

cheers,
Kai
