### PR TITLE
"ip-address" validator

### DIFF
--- a/validictory/tests/test_type.py
+++ b/validictory/tests/test_type.py
@@ -78,6 +78,12 @@ class TestType(TestCase):
         invalids = [1.2, "bad", {"test":"blah"}, [32, 49], 1284, True]
         self._test_type('null', valids, invalids)
 
+    def test_ip_address(self):
+        valids = ["0.0.0.0", "255.255.255.255"]
+        invalids = [1.2, "bad", {"test":"blah"}, [32, 49], 1284, True,
+                    "-0.-0.-0.-0", "-1.-1.-1.-1", "256.256.256.256"]
+        self._test_type('ip-address', valids, invalids)
+
     def test_any(self):
         valids = [1.2, "bad", {"test":"blah"}, [32, 49], None, 1284, True]
         self._test_type('any', valids, [])

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import copy
+import socket
 from datetime import datetime
 import warnings
 from collections import Mapping, Container
@@ -99,6 +100,15 @@ class SchemaValidator(object):
     def validate_type_null(self, val):
         return val is None
 
+    def validate_type_ip_address(self, val):
+        try:
+            socket.inet_aton(val)
+            # Make sure we expect "X.X.X.X" as socket.inet_aton() converts "1"
+            # to "0.0.0.1"
+            return len(val.split('.')) == 4
+        except:
+            return False
+
     def validate_type_any(self, val):
         return True
 
@@ -143,7 +153,8 @@ class SchemaValidator(object):
                     raise e
             else:
                 try:
-                    type_checker = getattr(self, 'validate_type_%s' % fieldtype)
+                    type_checker = getattr(self, 'validate_type_%s' %
+                                           fieldtype.replace('-', '_'))
                 except AttributeError:
                     raise SchemaError("Field type '%s' is not supported." %
                                       fieldtype)


### PR DESCRIPTION
I have implemented an IP address validator. Please pull.

Implementation notes:

The way the validator method name is resolved requires to have a .fieldtype.replace("-", "_") so "ip-address" becomes "ip_address", thus "self.validate_type_ip_address" can work.

I tried to move all validator methods as top-level module functions, and register them such as:

TYPE_CHECKERS = {'string': validate_type_string,
                 'integer': validate_type_integer,
                 'number': validate_type_number,
                 'boolean': validate_type_boolean,
                 'object': validate_type_object,
                 'array': validate_type_array,
                 'null': validate_type_null,
                 'ip-address': validate_type_ip_address,
                 'any': validate_type_any}

The problem is that it breaks custom validators as they extend the SchemaValidator class, such as:

DateValidator(validictory.validator.SchemaValidator): ...

So I thought about implementing a method on the SchemaValidator class, that would work like this:

def my_random_validator(val):
    return random.choice([True, False])

validictory.register_validator("random", my_random_validator)

That would basically insert the key "random" in the TYPE_CHECKERS dictionary, along with the appropriate validator.

But that would still break the tests, so I did not implement it. Unless there's another way I am not aware of...

Thanks,
Alex
