### PR TITLE
Ignoring additionalProperties with non-dicts

### DIFF
--- a/validictory/tests/test_properties.py
+++ b/validictory/tests/test_properties.py
@@ -162,6 +162,24 @@ class TestAdditionalProperties(TestCase):
             self.assertRaises(ValueError, validictory.validate, {"prop":x},
                               schema)
 
+    def test_false_with_type_string(self):
+        schema = {
+            "type": ["object", "string"],
+            "properties": {
+                "key": {"type":"string"}
+            },
+            "additionalProperties": False
+        }
+
+        for data in ["foobar", {'key':'value'}]:
+            try:
+                validictory.validate(data, schema)
+            except ValueError as e:
+                self.fail("Unexpected failure: %s" % e)
+
+        #failures
+        for data in [['foo','bar'], None, True, {'roses':'red'}]:
+            self.assertRaises(ValueError, validictory.validate, data, schema)
 
 class TestRequires(TestCase):
     '''

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -252,6 +252,12 @@ class SchemaValidator(object):
         Validates additional properties of a JSON object that were not
         specifically defined by the properties property
         '''
+
+        # Shouldn't be validating additionalProperties on non-dicts 
+        value = x.get(fieldname)
+        if not isinstance(value, dict):
+            return
+
         # If additionalProperties is the boolean value True then we accept
         # any additional properties.
         if isinstance(additionalProperties, bool) and additionalProperties:


### PR DESCRIPTION
Previously, validictory was throwing errors from `additionalProperties` even when the data being checked was a non-dict, and of a valid non-object type.  I've included a test case in the commit, but to wit:

``` python
from validictory import validate
validate('string is a valid type', {
    'type': ['array', 'string'],
    'properties': {
        'foo': { 'type':'string' }
    },
    'additionalProperties': False
})
```

Would throw:

```
validictory.validator.ValidationError: additional properties not defined by 'properties' are not allowed in field '_data'
```

The `additionalItems` validation was already skipping itself if the field was not a `tuple` or a `list`, so I just copied that check (except checking for `dict`, instead) over to `additionalProperties`.  All tests are passing.

The JSON Schema document is a little bit unclear on all of this, but I'm interpolating from this:

5.2.  properties

   This attribute is an object with property definitions that define the
   valid values of instance object property values.  When the instance
   value is an object, the property values of the instance object MUST
   conform to the property definitions in this object.  In this object,
   each property definition's value MUST be a schema, and the property's
   name MUST be the name of the instance property that it defines.  The
   instance property value MUST be valid according to the schema from
   the property definition.  Properties are considered unordered, the
   order of the instance properties MAY be in any order.

From that, "When the instance value is an object",

5.6.  additionalItems

   This provides a definition for additional items in an array instance
   when tuple definitions of the items is provided.  This can be false
   to indicate additional items in the array are not allowed, or it can
   be a schema that defines the schema of the additional items.

From that, "in an array instance",

5.4.  additionalProperties

   This attribute defines a schema for all properties that are not
   explicitly defined in an object type definition.  If specified, the
   value MUST be a schema or a boolean.  If false is provided, no
   additional properties are allowed beyond the properties defined in
   the schema.  The default value is an empty schema which allows any
   value for additional properties.

Even though it doesn't specifically say "when the instance value is an object", I think it's implied from the fact that 5.2 "properties" only apply to "when the instance value is an object," and 5.6 "additionalItems" is ignored when its instance object is not of an applicable type (in that case, array).
