### PR TITLE
Fix handling empty patternProperties when it's not required"

### DIFF
--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -235,7 +235,7 @@ class SchemaValidator(object):
         if patternproperties == None:
             patternproperties = {}
 
-        value_obj = x.get(fieldname)
+        value_obj = x.get(fieldname, {})
 
         for pattern, schema in patternproperties.items():
             for key, value in value_obj.items():


### PR DESCRIPTION
Simple fix this case 
{
    "$schema": "http://json-schema.org/draft-03/hyper-schema#",
    "id": "http://example.com/schema#",
    "name": "ExampleSchema",
    "type": "object",
    "additionalProperties": true,
    "properties": {
        "id": {
            "minLength": 1,
            "required": true,
            "type": "string"
        },
        "patprops": {
            "required": false,
            "type": "object",
            "patternProperties": {
                ".*$": {
                    "required": true,
                    "type": "array",
                    "uniqueItems": true,
                    "items": [
                        {
                            "type": "string"
                        }
                    ]
                }
            }
        }
    }
}

validictory.validate({"id": "1"},  schema)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.6/dist-packages/validictory-0.8.1-py2.6.egg/validictory/**init**.py", line 28, in validate
    return v.validate(data, schema)
  File "/usr/local/lib/python2.6/dist-packages/validictory-0.8.1-py2.6.egg/validictory/validator.py", line 496, in validate
    self._validate(data, schema)
  File "/usr/local/lib/python2.6/dist-packages/validictory-0.8.1-py2.6.egg/validictory/validator.py", line 499, in _validate
    self.__validate("_data", {"_data": data}, schema)
  File "/usr/local/lib/python2.6/dist-packages/validictory-0.8.1-py2.6.egg/validictory/validator.py", line 528, in __validate
    newschema.get(schemaprop))
  File "/usr/local/lib/python2.6/dist-packages/validictory-0.8.1-py2.6.egg/validictory/validator.py", line 178, in validate_properties
    properties.get(eachProp))
  File "/usr/local/lib/python2.6/dist-packages/validictory-0.8.1-py2.6.egg/validictory/validator.py", line 528, in __validate
    newschema.get(schemaprop))
  File "/usr/local/lib/python2.6/dist-packages/validictory-0.8.1-py2.6.egg/validictory/validator.py", line 241, in validate_patternProperties
    for key, value in value_obj.items():
AttributeError: 'NoneType' object has no attribute 'items'
