### PR TITLE
Support for disallow_unknown_properties option

### DIFF
--- a/validictory/__init__.py
+++ b/validictory/__init__.py
@@ -8,7 +8,7 @@ __version__ = '0.9.0-dev'
 
 def validate(data, schema, validator_cls=SchemaValidator,
              format_validators=None, required_by_default=True,
-             blank_by_default=False):
+             blank_by_default=False, disallow_unknown_properties=False):
     '''
     Validates a parsed json document against the provided schema. If an
     error is found a :class:`ValidationError` is raised.
@@ -23,8 +23,11 @@ def validate(data, schema, validator_cls=SchemaValidator,
     :param format_validators: optional dictionary of custom format validators
     :param required_by_default: defaults to True, set to False to make
         ``required`` schema attribute False by default.
+    :param disallow_unknown_properties: defaults to False, set to True to
+        disallow properties not listed in the schema definition
     '''
-    v = validator_cls(format_validators, required_by_default, blank_by_default)
+    v = validator_cls(format_validators, required_by_default, blank_by_default,
+                      disallow_unknown_properties)
     return v.validate(data, schema)
 
 if __name__ == '__main__':

--- a/validictory/tests/test_disallow_unknown_properties.py
+++ b/validictory/tests/test_disallow_unknown_properties.py
@@ -1,0 +1,72 @@
+from unittest import TestCase
+
+import validictory
+
+
+class TestDisallowUnknownProperties(TestCase):
+
+    def setUp(self):
+        self.data_simple = {"name": "john doe", "age": 42}
+        self.schema_simple = {
+                "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "age": {"type": "integer"}
+                     },
+        }
+
+        self.data_complex = {
+            "inv_number": "123",
+            "rows": [
+                {
+                    "sku": "ab-456",
+                    "desc": "a description",
+                    "price": 100.45
+                },
+                {
+                    "sku": "xy-123",
+                    "desc": "another description",
+                    "price": 999.00
+                }
+            ]
+        }
+        self.schema_complex = {
+            "type": "object",
+            "properties": {
+                "inv_number": {"type": "string"},
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "sku": {"type": "string"},
+                        "desc": {"type": "string"},
+                        "price": {"type": "number"}
+                     },
+                }
+             }
+        }
+    def test_disallow_unknown_properties_pass(self):
+        try:
+            validictory.validate(self.data_simple, self.schema_simple,
+                                 disallow_unknown_properties=True)
+        except ValueError as e:
+            self.fail("Unexpected failure: %s" % e)
+
+    def test_disallow_unknown_properties_fail(self):
+        self.data_simple["sex"] = "male"
+        self.assertRaises(validictory.SchemaError, validictory.validate,
+                          self.data_simple, self.schema_simple,
+                          disallow_unknown_properties=True)
+
+    def test_disallow_unknown_properties_complex_pass(self):
+        try:
+            validictory.validate(self.data_complex, self.schema_complex,
+                                 disallow_unknown_properties=True)
+        except ValueError as e:
+            self.fail("Unexpected failure: %s" % e)
+
+    def test_disallow_unknown_properties_complex_fail(self):
+        newrow = {"sku": "789", "desc": "catch me if you can", "price": 1, "rice": 666}
+        self.data_complex["rows"].append(newrow)
+        self.assertRaises(validictory.SchemaError, validictory.validate,
+                          self.data_complex, self.schema_complex,
+                          disallow_unknown_properties=True)

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -85,16 +85,19 @@ class SchemaValidator(object):
         ``required`` schema attribute False by default.
     :param blank_by_default: defaults to False, set to True to make ``blank``
         schema attribute True by default.
+    :param disallow_unknown_properties: defaults to False, set to True to
+        disallow properties not listed in the schema definition
     '''
 
     def __init__(self, format_validators=None, required_by_default=True,
-                 blank_by_default=False):
+                 blank_by_default=False, disallow_unknown_properties=False):
         if format_validators is None:
             format_validators = DEFAULT_FORMAT_VALIDATORS.copy()
 
         self._format_validators = format_validators
         self.required_by_default = required_by_default
         self.blank_by_default = blank_by_default
+        self.disallow_unknown_properties = disallow_unknown_properties
 
     def register_format_validator(self, format_name, format_validator_fun):
         self._format_validators[format_name] = format_validator_fun
@@ -128,6 +131,19 @@ class SchemaValidator(object):
         params['fieldname'] = fieldname
         message = desc % params
         raise ValidationError(message)
+
+    def _validate_unknown_properties(self, schema, data, fieldname):
+        schema_properties = set(schema)
+        data_properties = set(data)
+        delta = data_properties - schema_properties
+        if delta:
+            unknowns = ''
+            for x in delta:
+                unknowns += '"%s", ' % x
+            unknowns = unknowns.rstrip(", ")
+            raise SchemaError('Unknown properties for field '
+                              '"%(fieldname)s": %(unknowns)s' %
+                              locals())
 
     def validate_type(self, x, fieldname, schema, fieldtype=None):
         '''
@@ -185,6 +201,10 @@ class SchemaValidator(object):
             value = x.get(fieldname)
             if isinstance(value, dict):
                 if isinstance(properties, dict):
+
+                    if self.disallow_unknown_properties:
+                        self._validate_unknown_properties(properties, value, fieldname)
+
                     for eachProp in properties:
                         self.__validate(eachProp, value,
                                         properties.get(eachProp))
@@ -217,6 +237,9 @@ class SchemaValidator(object):
                                               (fieldname, e))
                 elif isinstance(items, dict):
                     for eachItem in value:
+                        if self.disallow_unknown_properties:
+                            self._validate_unknown_properties(items, eachItem, fieldname)
+
                         try:
                             self._validate(eachItem, items)
                         except ValueError as e:


### PR DESCRIPTION
Support for disallow_unknown_properties option, available both in the validate method and in the SchemaValidator contstructor. Set to True to prevent injection of unwanted property/value pairs in your document. Defaults to False.

While you can achieve similar results by setting 'additionalProperties = False', that only works for 'object' types and not for the 'array' type. When an array's 'items' property is set to a schema, it will accept any number of incoming dicts (objects) making sure that known fields match the schema, but still allowing for unknown/unmatched fields (the 'additionalItems' property will only block multiple array items).

Look at the test_disallow_unknown_properties.py module for usage examples.

PS: as an alternative (more verbose, perhaps more coherent) solution would be to provide an array property that does what 'additionalProperty = False' does for 'object' types. Since 'additionalItems' does something else already, maybe something like 'allowUnknownProperties'... 
