### PR TITLE
Allow Decimal to be used in number

### DIFF
--- a/validictory/tests/test_type.py
+++ b/validictory/tests/test_type.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from decimal import Decimal
 import datetime
 import sys
 
@@ -54,7 +55,7 @@ class TestType(TestCase):
         self._test_type('string', valids, invalids)
 
     def test_number(self):
-        valids = [1.2, -89.42, 48, -32]
+        valids = [1.2, -89.42, 48, -32, Decimal('25.25')]
         invalids = ["bad", {"test":"blah"}, [32.42, 494242], None, True]
         self._test_type('number', valids, invalids)
 

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -3,6 +3,7 @@ import sys
 import copy
 import socket
 from datetime import datetime
+from decimal import Decimal
 from collections import Mapping, Container
 
 if sys.version_info[0] == 3:
@@ -106,7 +107,7 @@ class SchemaValidator(object):
         return type(val) in _int_types
 
     def validate_type_number(self, val):
-        return type(val) in _int_types + (float,)
+        return type(val) in _int_types + (float, Decimal,)
 
     def validate_type_boolean(self, val):
         return type(val) == bool
@@ -529,7 +530,7 @@ class SchemaValidator(object):
 
         if schema is not None:
             if not isinstance(schema, dict):
-                raise SchemaError("Type for field '%s' must be 'dict', got: '%s'" 
+                raise SchemaError("Type for field '%s' must be 'dict', got: '%s'"
                                  % (fieldname, type(schema).__name__))
 
             newschema = copy.copy(schema)


### PR DESCRIPTION
Json parsers allow a custom type to be used for parsing float values. It is common practice to use Decimal as float storage to prevent precision loss. 

Example:

```
    parsed_data = json.loads(raw_data, parse_float=Decimal)
    validictory.validate(parsed_data, SCHEMA)
```

would fail horrible with now option to allow Decimal to be used. 

A better approach would be to extend the API and allow users to specify which types are allowed in which case. This commit fixes my current issue with Decimal though. 
