### PR TITLE
Proposed fix for GH-43: When data doesn't match one of several possible types, include the validation error for each of those types.

### DIFF
--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -175,17 +175,18 @@ class SchemaValidator(object):
             if isinstance(fieldtype, (list, tuple)):
                 # Match if type matches any one of the types in the list
                 datavalid = False
+                errorlist = []
                 for eachtype in fieldtype:
                     try:
                         self.validate_type(x, fieldname, eachtype, eachtype)
                         datavalid = True
                         break
-                    except ValidationError:
-                        pass
+                    except ValidationError as err:
+                        errorlist.append(err)
                 if not datavalid:
-                    self._error("Value %(value)r for field '%(fieldname)s' is "
-                                "not of type %(fieldtype)s",
-                                value, fieldname, fieldtype=fieldtype)
+                    self._error("Value %(value)r for field '%(fieldname)s' doesn't "
+                                "match any of %(numsubtypes)d subtypes in %(fieldtype)s; errorlist = %(errorlist)r",
+                                value, fieldname, numsubtypes=len(fieldtype), fieldtype=fieldtype, errorlist=errorlist)
             elif isinstance(fieldtype, dict):
                 try:
                     self.__validate(fieldname, x, fieldtype)


### PR DESCRIPTION
This is a proposed fix for GH-43.

There might be a better way of displaying this error and I'm certainly open to suggestions. This seems a little better than the current behavior. Maybe someone can think of an even better way.

With this change, the output looks like:

```
Value {'a': 1} for field '_data' doesn't match any of 2 subtypes in [{'type': 'object', 'properties': {'a': {'type': 'integer'}, 'b': {'type': 'integer'}}}, {'type': 'object', 'properties': {'a': {'type': 'integer'}, 'c': {'type': 'integer'}}}]; errorlist = [FieldValidationError("Required field 'b' is missing",), FieldValidationError("Required field 'c' is missing",)]
```

(scroll to the right and look for `errorlist`)

which is still hard to read because of the long JSON schema on a single line, but at least it gives some clues at the end as to what the problems were when trying to match each of the sub-schemas.
