### PR TITLE
Fix the disallow_unknown_properties option

### DIFF
--- a/validictory/tests/test_disallow_unknown_properties.py
+++ b/validictory/tests/test_disallow_unknown_properties.py
@@ -37,9 +37,12 @@ class TestDisallowUnknownProperties(TestCase):
                 "rows": {
                     "type": "array",
                     "items": {
-                        "sku": {"type": "string"},
-                        "desc": {"type": "string"},
-                        "price": {"type": "number"}
+                        "type": "object",
+                        "properties": {
+                            "sku": {"type": "string"},
+                            "desc": {"type": "string"},
+                            "price": {"type": "number"}
+                        }
                     },
                 }
             }

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -250,8 +250,8 @@ class SchemaValidator(object):
                                               (fieldname, e), fieldname, e.value)
                 elif isinstance(items, dict):
                     for eachItem in value:
-                        if self.disallow_unknown_properties:
-                            self._validate_unknown_properties(items, eachItem,
+                        if self.disallow_unknown_properties and 'properties' in items:
+                            self._validate_unknown_properties(items['properties'], eachItem,
                                                               fieldname)
 
                         try:


### PR DESCRIPTION
the disallow_unknown_properties option when set to True, prevented array validation. fixed the code and the test that had a faulty schema.
