### PR TITLE
support email format validator

### DIFF
--- a/validictory/tests/test_values.py
+++ b/validictory/tests/test_values.py
@@ -221,8 +221,8 @@ class TestFormat(TestCase):
                           self.schema_spaces)
 
     def test_format_email_pass(self):
-        valids = ["foo@foo.com", "foo.bar@foo.bar.baz",
-                  "foo+bar@foo.com", "foo'.+bar@ba.fu.blah"]
+        valids = ["foo@foo.com", "foo.bar@foo.bar.baz", "foo+bar@foo.com",
+                  "foo'.+bar@ba.fu.blah", "ALEX@GMAIL.COM"]
         for email in valids:
             try:
                 validictory.validate(email, self.schema_email)
@@ -231,7 +231,8 @@ class TestFormat(TestCase):
 
     def test_format_email_fail(self):
         invalids = [1.2, "bad", {"test": "blah"}, [32, 49], 1284, True,
-                    "foo@", "@example.com"]
+                    "foo@", "@example.com", "alex..@gmail.com",
+                    "ALEX@GMAIL..COM", "al..ex@gmail.com"]
         for email in invalids:
             self.assertRaises(ValueError, validictory.validate, email,
                               self.schema_email)

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -78,15 +78,12 @@ def validate_format_ip_address(validator, fieldname, value, format_option):
                               "not a ip-address" % locals(), fieldname, value)
 
 
-# This is the assembled, zlib'ed and base64'ed email regex used here:
-# https://github.com/SyrusAkbary/validate_email
-RE_EMAIL_ZLIB_B64 = """\
-eJztld0KgkAQhV+lHytH0dIQI4jtPTwrWellFxEktPXszXbhZUvhhSuCR2bdo3x7RpjcFdvmyka4
-SY8LXHEhEp+1TwKu0aK3UK+igG8b1pF1YlX8IKpQp6xY78Ypq+AiYUty5iItpdIfREhEnoGkcViC
-q74auMB9PHVmcyzgwUew3EEgP+ABhedL+vqV0GSyLBPLcE0tVFadpmfhT1pCZa3/pTQzdCnRnv0A
-tB8m2DDBhhYOE6yjuKbwkbXHmhSs8ldEaVWePWs/OW/YydOX"""
+# An email regex found here:
+# http://www.regular-expressions.info/email.html
+RE_EMAIL = """[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@\
+(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"""
 
-RE_EMAIL = re.compile(RE_EMAIL_ZLIB_B64.decode('base64').decode('zlib'))
+RE_EMAIL = re.compile(RE_EMAIL, re.I)
 
 
 def validate_format_email(validator, fieldname, value, format_option):


### PR DESCRIPTION
Before:

``` python
>>> import validictory
>>> validictory.validate("foo", {"type":"string", "format":"email"})
>>> 
```

After:

``` python
>>> import validictory
>>> validictory.validate("foo", {"type":"string", "format":"email"})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "validictory/__init__.py", line 31, in validate
    return v.validate(data, schema)
  File "validictory/validator.py", line 574, in validate
    self._validate(data, schema)
  File "validictory/validator.py", line 577, in _validate
    self.__validate("_data", {"_data": data}, schema)
  File "validictory/validator.py", line 608, in __validate
    newschema.get(schemaprop))
  File "validictory/validator.py", line 470, in validate_format
    format_validator(self, fieldname, value, format_option)
  File "validictory/validator.py", line 91, in validate_format_email
    "not an email" % locals(), fieldname, value)
validictory.validator.FieldValidationError: Value 'foo' of field '_data' is not an email
>>> 
```
