### PR TITLE
Documentation improvements and fixes to user provided format_validators

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -169,7 +169,6 @@ Schema Options
         "properties": {
 
             "one": {
-
                 "type": "array"
             },
             "two": {

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -109,10 +109,15 @@ class SchemaValidator(object):
     def __init__(self, format_validators=None, required_by_default=True,
                  blank_by_default=False, disallow_unknown_properties=False,
                  apply_default_to_data=False):
-        if format_validators is None:
-            format_validators = DEFAULT_FORMAT_VALIDATORS.copy()
 
-        self._format_validators = format_validators
+        # add the default format validators
+        for key, value in DEFAULT_FORMAT_VALIDATORS:
+            self.register_format_validator(key, value)
+
+        # register any custom format validators if they were provided
+        if format_validators:
+            for key, value in format_validators:
+                self.register_format_validator(key, value)
         self.required_by_default = required_by_default
         self.blank_by_default = blank_by_default
         self.disallow_unknown_properties = disallow_unknown_properties


### PR DESCRIPTION
I added a lot of examples to usage.rst, as I had to use this library recently and it was kind of annoying how it wasn't clear how to use a lot of stuff. Also, I noticed that in the constructor to SchemaValidator, if the user provided a custom dictionary of format validators, the 'default validators' would be cleared and the user would not be able to use them, so i made it so that it uses the previously unused 'register_format_validator' for each item in the 'default validators' dictionary, and then if there is a user provided one, we register all the ones in that dictionary as well. No attempt is made to prevent naming conflicts at the moment!
