### PR TITLE
Small changes in documentation formatting / python examples

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -196,7 +196,6 @@ Schema Options
 ::
 
     # given a schema object, every list will be validated against it. 
-
     data = json.loads(''' {"results": [1, 2, 3, 4, 5]}''')
 
     schema =    {
@@ -211,8 +210,8 @@ Schema Options
     validictory.validate(data, schema)
 
     # given a list, each item in the list is matched against the schema
-    # in the order given
-
+    # at the same index. (entry 0 in the json will be matched against entry 0
+    # in the schema, etc)
     dataTwo = json.loads(''' {"results": [1, "a", false, null, 5.3]}  ''')
     schemaTwo = {
                     "properties": {


### PR DESCRIPTION
Hello,

Upon viewing the documentation on read the docs, I noticed some of the formatting was a bit off, which I didn't really catch before as i wasn't viewing the parsed results on readthedocs but using something called 'restview' which is a python script that shows the parsed RST in a web browser, but obviously read the docs has its own CSS styles and whatnot.

So i made some 'small' changes, like making the code examples only 80 lines long so no horizontal scroll bar has to appear (like in the 'format' code example), and making a string format call consistent with the python 2 syntax, and modified another code example's comment.

So hopefully this can be merged without pain (sorry about not catching the dict.items() problem before and causing the tests to fail, I swore i didn't see the error when i ran the tests myself o.o)

~Mark
