### PR TITLE
Run format fn on falsey values

### DIFF
--- a/validictory/tests/test_values.py
+++ b/validictory/tests/test_values.py
@@ -64,6 +64,16 @@ def validate_format_contains_spaces(validator, fieldname, value,
         "but it should" % locals(), fieldname, value)
 
 
+def validate_format_dict_not_empty(validator, fieldname, value,
+                               format_option):
+    if len(value.keys()) > 0:
+        return
+
+    raise validictory.FieldValidationError(
+        "Value %(value)r of field '%(fieldname)s' should not be an empty"
+        "dict" % locals(), fieldname, value)
+
+
 class TestFormat(TestCase):
 
     schema_datetime = {"format": "date-time"}
@@ -72,6 +82,7 @@ class TestFormat(TestCase):
     schema_utcmillisec = {"format": "utc-millisec"}
     schema_ip = {"format": "ip-address"}
     schema_spaces = {"format": "spaces"}
+    schema_non_empty_dict = {"type": "object", "format": "non-empty-dict"}
 
     def test_format_datetime_pass(self):
         data = "2011-01-13T10:56:53Z"
@@ -223,6 +234,15 @@ class TestFormat(TestCase):
         # validator registered, but data does not conform
         self.assertRaises(ValueError, validator.validate, data,
                           self.schema_spaces)
+
+    def test_format_non_empty_fail(self):
+        data = {}
+
+        validator = validictory.SchemaValidator(
+            {'non-empty-dict': validate_format_dict_not_empty})
+
+        self.assertRaises(ValueError, validator.validate, data,
+                          self.schema_non_empty_dict)
 
 
 class TestUniqueItems(TestCase):

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -435,11 +435,11 @@ class SchemaValidator(object):
         '''
         Validates the format of primitive data types
         '''
-        value = x.get(fieldname)
+        value = x.get(fieldname, None)
 
         format_validator = self._format_validators.get(format_option, None)
 
-        if format_validator and value:
+        if format_validator and value is not None:
             try:
                 format_validator(self, fieldname, value, format_option)
             except FieldValidationError as fve:


### PR DESCRIPTION
Right now, a format function will be skipped if the value is python false-y (ie. `{}` or 0, etc) but even in these cases, it makes sense to still run the format function. This change will make it so that the format function will only _not_ run if there is a null value in the field
