### PR TITLE
store fieldname and path for validation errors

### DIFF
--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -31,6 +31,7 @@ class FieldValidationError(ValidationError):
         super(FieldValidationError, self).__init__(message)
         self.fieldname = fieldname
         self.value = value
+        self.path = path
 
 
 class DependencyValidationError(ValidationError):
@@ -180,6 +181,8 @@ class SchemaValidator(object):
             err = FieldValidationError(message, fieldname, value, path)
         elif exctype == DependencyValidationError or exctype == RequiredFieldValidationError:
             err = exctype(message)
+            err.fieldname = fieldname
+            err.path = path
 
         if self.fail_fast:
             raise err


### PR DESCRIPTION
Idea for patch is to capture field name also with DependencyValidationError and RequiredFieldValidationError. Also, path to field is stored for all three errors.

Possible problems with backward compatibility:
if one uses in subclasses of DependencyValidationError / RequiredFieldValidationError fieldname and/or path properties then these will be overwritten after \__init\__ method.
If one has defined \__slots\__ for subclasses of these two, setting fieldname and path will fail probably too.