### PR TITLE
avoid schema copying if values can be optional and blank

### DIFF
--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -589,12 +589,18 @@ class SchemaValidator(object):
                 raise SchemaError("Type for field '%s' must be 'dict', got: '%s'" %
                                   (fieldname, type(schema).__name__))
 
-            newschema = copy.copy(schema)
+            add_required_rule = self.required_by_default and 'required' not in schema
+            add_not_blank_rule = not self.blank_by_default and 'blank' not in schema
 
-            if 'required' not in schema:
-                newschema['required'] = self.required_by_default
-            if 'blank' not in schema:
-                newschema['blank'] = self.blank_by_default
+            if add_required_rule or add_not_blank_rule:
+                newschema = copy.copy(schema)
+
+                if add_required_rule:
+                    newschema['required'] = self.required_by_default
+                if add_not_blank_rule:
+                    newschema['blank'] = self.blank_by_default
+            else:
+                newschema = schema
 
             # add default values first before checking for required fields
             if self.apply_default_to_data and 'default' in schema:


### PR DESCRIPTION
If one uses configuration (not required by default, blank by default) then there is no need to make copy of schema and add rules 'required' and 'blank'.

I get following timing using this script:

```python
        schema = {
            'properties': {
                 'fs1': {'type': 'string'}
                ,'fs2': {'type': 'string', 'required': True}
                ,'fs3': {'type': 'string', 'required': True}
                ,'fe4': {'enum': ['A', 'B'], 'required': True}
                ,'fd5': {'type': 'string', 'format': 'date', 'required': True}
            }
        }

        data = {
            'fs1': 'text fs1',
            'fs2': 'text fs2',
            'fs3': 'text fs2',
            'fe4': 'B',
            'fd5': '1967-09-23'
        }

        stmt = 'validate(%s, %s, required_by_default=True, blank_by_default=True)' % (repr(data), repr(schema))
        print timeit.timeit(stmt, setup='from validictory import validate', number=100000)

        stmt = 'validate(%s, %s, required_by_default=False, blank_by_default=True)' % (repr(data), repr(schema))
        print timeit.timeit(stmt, setup='from validictory import validate', number=100000)
```

Before change:
4.34
4.28

After:
3.57
3.22

Backward compatibility problems:
None if schema is not changed during validation.
