### PR TITLE
Added functionality to support microseconds for date-time validation

### DIFF
--- a/validictory/tests/test_values.py
+++ b/validictory/tests/test_values.py
@@ -106,8 +106,16 @@ class TestFormat(TestCase):
     schema_spaces = {"format": "spaces"}
     schema_non_empty_dict = {"type": "object", "format": "non-empty-dict"}
 
-    def test_format_datetime_pass(self):
+    def test_format_datetime_without_microseconds_pass(self):
         data = "2011-01-13T10:56:53Z"
+
+        try:
+            validictory.validate(data, self.schema_datetime)
+        except ValueError as e:
+            self.fail("Unexpected failure: %s" % e)
+
+    def test_format_datetime_with_microseconds_pass(self):
+        data = "2011-01-13T10:56:53.0438Z"
 
         try:
             validictory.validate(data, self.schema_datetime)

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -60,7 +60,16 @@ class MultipleValidationError(ValidationError):
 def _generate_datetime_validator(format_option, dateformat_string):
     def validate_format_datetime(validator, fieldname, value, format_option):
         try:
-            datetime.strptime(value, dateformat_string)
+            # Additions to support date-time with microseconds without breaking existing date-time validation.
+            # Microseconds will appear specifically separated by a period, as some variable length decimal number
+            # such as  '2015-11-18T19:57:05.061Z'  instead of  '2015-11-18T19:57:05Z'  Better would be to use
+            # strict_rfc3339 vs datetime.strptime though the user needs the package installed for the import to succeed.
+            #     import strict_rfc3339
+            #     assert strict_rfc3339.validate_rfc3339(value)
+            if format_option == 'date-time' and '.' in value:
+                datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+            else:
+                datetime.strptime(value, dateformat_string)
         except:
             msg = "is not in '{format_option}' format"
             raise FieldValidationError(msg.format(format_option=format_option), fieldname, value)


### PR DESCRIPTION
Ohhh, my first pull request against a public repository. Fun!

Modified validate_format_date_time to continue to use datetime.strptime as opposed to attempting to import and leverage strict_rfc3339 which is what I've been doing locally. This should maintain the existing functionality as well as add support for mine where I'm getting MongoDB ISODates from my API with microseconds and need to validate it against schema date-time.

Also modified one existing and and added one new datetime testcase to clearly test against date-time with and without milliseconds.