### PR TITLE
Remove manipulation of sys.path in one test-file.

### DIFF
--- a/validictory/tests/test_fail_fast.py
+++ b/validictory/tests/test_fail_fast.py
@@ -1,8 +1,5 @@
 from unittest import TestCase
 
-import sys, os
-sys.path = [ os.path.join( os.path.dirname( __file__ ), '..' ) ] + sys.path
-
 import validictory
 
 


### PR DESCRIPTION
This file was the only one manipulating sys.path. This let to asymmetric
behavior in some special test-environment I have (packaging for guix
(https://www.gnu.org/software/guix/). This change has no effect on
"normal" environments.