### PR TITLE
validate_type allows an item to raise a SchemaError

### DIFF
--- a/validictory/tests/test_disallow_unknown_properties.py
+++ b/validictory/tests/test_disallow_unknown_properties.py
@@ -28,7 +28,11 @@ class TestDisallowUnknownProperties(TestCase):
                     "desc": "another description",
                     "price": 999.00
                 }
-            ]
+            ],
+            "data": {
+                "name": "john doe",
+                "age": 42
+            }
         }
         self.schema_complex = {
             "type": "object",
@@ -44,6 +48,32 @@ class TestDisallowUnknownProperties(TestCase):
                             "price": {"type": "number"}
                         }
                     },
+                },
+                "data": {
+                    "type": (
+                        {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "hair": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "age": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    )
                 }
             }
         }

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -246,7 +246,7 @@ class SchemaValidator(object):
 
                         datavalid = True
                         break
-                    except ValidationError as err:
+                    except (SchemaError, ValidationError) as err:
                         errorlist.append(err)
                 if not datavalid:
                     self._error("doesn't match any of {numsubtypes} subtypes in {fieldtype}; "


### PR DESCRIPTION
Allows a list of types to be validated if any of the items in the list raises a SchemaError.

Raised as issue https://github.com/jamesturk/validictory/issues/107