### PR TITLE
Dont reuse pointers to default dict or lists

### DIFF
--- a/validictory/tests/test_apply_default.py
+++ b/validictory/tests/test_apply_default.py
@@ -89,3 +89,33 @@ class TestItemDefaults(TestCase):
 
         # the original data is unchanged
         self.assertEqual(data, {'foo': 1})
+
+    def test_property_default_has_different_memory_id(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "default": []
+                }
+            }
+        }
+
+        data = {}
+
+        validictory.validate(
+            data,
+            schema,
+            required_by_default=True,
+            apply_default_to_data=True
+        )
+
+        # correctly apply default
+        self.assertEqual({"foo":[]}, data)
+
+        # dont re-use the actual array from the schema
+        applied_default_id = id(data["foo"])
+        original_schema_id = id(schema["properties"]["foo"]["default"])
+        self.assertNotEqual(applied_default_id, original_schema_id)
+
+
+

--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -161,6 +161,11 @@ class SchemaValidator(object):
     def register_format_validator(self, format_name, format_validator_fun):
         self._format_validators[format_name] = format_validator_fun
 
+    def get_default(self, value):
+        if isinstance(value, dict) or isinstance(value, list):
+            return copy.deepcopy(value)
+        return value
+
     def validate_type_string(self, val):
         return isinstance(val, _str_type)
 
@@ -637,7 +642,7 @@ class SchemaValidator(object):
             # add default values first before checking for required fields
             if self.apply_default_to_data and 'default' in schema:
                 try:
-                    self.validate_type(x={'_ds': schema['default']}, fieldname='_ds',
+                    self.validate_type(x={'_ds': self.get_default(schema['default'])}, fieldname='_ds',
                                        schema=schema,
                                        fieldtype=schema['type'] if 'type' in schema else None,
                                        path=path)
@@ -645,7 +650,7 @@ class SchemaValidator(object):
                     raise SchemaError(exc)
 
                 if fieldname not in data:
-                    data[fieldname] = schema['default']
+                    data[fieldname] = self.get_default(schema['default'])
 
             # iterate over schema and call all validators
             for schemaprop in newschema:


### PR DESCRIPTION
When using an array or an object as a default value:
```
        schema = {
            "type": "object",
            "properties": {
                "foo": {
                    "default": []
                }
            }
        }
```
The pointer to the array *in the schema** is reused as the pointer to the object that gets validated and applied with a default! This leads to really odd bugs where each time you validate an object, the array from the previous validation may be getting reused!

Continuing with the schema above, I wrote a failing test, using the `id` method:

```
        data = {}

        validictory.validate(
            data,
            schema,
            required_by_default=True,
            apply_default_to_data=True
        )

        # correctly apply default
        self.assertEqual({"foo":[]}, data)

        # dont re-use the actual array from the schema
        applied_default_id = id(data["foo"])
        original_schema_id = id(schema["properties"]["foo"]["default"])

        self.assertNotEqual(applied_default_id, original_schema_id)
```

In order to get this test passing, we deep clone any defaults that are of instance `dict` or `list`.

Please let me know if there's anything I need to do to get this merged! Thanks